### PR TITLE
Docker pull latest version

### DIFF
--- a/pindel-somatic.cwl.yaml
+++ b/pindel-somatic.cwl.yaml
@@ -5,7 +5,7 @@ cwlVersion: v1.0
 baseCommand: [python, /opt/pindel.py, -t, NORMAL, -t TUMOR]
 requirements:
   - class: "DockerRequirement"
-    dockerPull: "opengenomics/pindel:0.2.5b8"
+    dockerPull: "opengenomics/pindel:latest"
 
 inputs:
   - id: "normal"


### PR DESCRIPTION
I'm thinking that it's useful to have the master branch have docker image versions of "latest". This makes it easy to develop and rebuild images, and to commit those fixes and have the version match docker hub.

Specific versions should be set when a tool/workflow is tagged in git (and therefore docker hub).